### PR TITLE
Update gemspec to use updated rpam module

### DIFF
--- a/devise_pam_authenticatable.gemspec
+++ b/devise_pam_authenticatable.gemspec
@@ -34,19 +34,8 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.4.2}
   s.summary = %q{Devise PAM authentication module using rpam}
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 3
+  s.required_ruby_version = Gem::Version::Requirement.new(">= 1.9.1")
 
-    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<devise>, ["> 1.1.0"])
-      s.add_runtime_dependency(%q<rpam>, [">= 0"])
-    else
-      s.add_dependency(%q<devise>, ["> 1.1.0"])
-      s.add_dependency(%q<rpam>, [">= 0"])
-    end
-  else
-    s.add_dependency(%q<devise>, ["> 1.1.0"])
-    s.add_dependency(%q<rpam>, [">= 0"])
-  end
+  s.add_dependency "rpam-ruby19"
 end
 


### PR DESCRIPTION
STR2CSTR is deprecated in Ruby 1.9.  Depend on rpam-ruby19 (https://github.com/canweriotnow/rpam-ruby19) to correct this.
